### PR TITLE
Убери приоритет из каналов (vibe-kanban)

### DIFF
--- a/app/controllers/concerns/telegram/subscription_commands.rb
+++ b/app/controllers/concerns/telegram/subscription_commands.rb
@@ -6,7 +6,7 @@ module Telegram::SubscriptionCommands
   included do
     # Команда /list - показать список подписок
     def list!(*)
-      subscriptions = current_user.subscriptions.includes(:channel).active.by_priority
+      subscriptions = current_user.subscriptions.includes(:channel).active.by_created_at
 
       if subscriptions.empty?
         respond_with :message, text: I18n.t('telegram_bot.channels.list.empty')
@@ -20,7 +20,7 @@ module Telegram::SubscriptionCommands
     # Callback query: мои подписки
     def my_subscriptions_callback_query(*)
       answer_callback_query('')
-      subscriptions = current_user.subscriptions.includes(:channel).active.by_priority
+      subscriptions = current_user.subscriptions.includes(:channel).active.by_created_at
 
       if subscriptions.empty?
         if payload['message']
@@ -75,49 +75,7 @@ module Telegram::SubscriptionCommands
 
         edit_message :text,
           text: I18n.t('telegram_bot.channels.list.remove_success', channel: "@#{channel.username}"),
-          reply_markup: subscriptions_keyboard(current_user.subscriptions.active.by_priority)
-      end
-    end
-
-    # Callback query: увеличить приоритет канала
-    def priority_up_callback_query(channel_id)
-      answer_callback_query('')
-      subscription = current_user.subscriptions.active.find_by(channel_id: channel_id)
-      if subscription && subscription.priority < 10
-        subscription.update(priority: subscription.priority + 1)
-
-        # Обновляем сообщение с новым списком
-        subscriptions = current_user.subscriptions.includes(:channel).active.by_priority
-        if payload['message']
-          edit_message :text,
-            text: build_subscriptions_list(subscriptions),
-            reply_markup: subscriptions_keyboard(subscriptions)
-        else
-          respond_with :message,
-            text: build_subscriptions_list(subscriptions),
-            reply_markup: subscriptions_keyboard(subscriptions)
-        end
-      end
-    end
-
-    # Callback query: уменьшить приоритет канала
-    def priority_down_callback_query(channel_id)
-      answer_callback_query('')
-      subscription = current_user.subscriptions.active.find_by(channel_id: channel_id)
-      if subscription && subscription.priority > 1
-        subscription.update(priority: subscription.priority - 1)
-
-        # Обновляем сообщение с новым списком
-        subscriptions = current_user.subscriptions.includes(:channel).active.by_priority
-        if payload['message']
-          edit_message :text,
-            text: build_subscriptions_list(subscriptions),
-            reply_markup: subscriptions_keyboard(subscriptions)
-        else
-          respond_with :message,
-            text: build_subscriptions_list(subscriptions),
-            reply_markup: subscriptions_keyboard(subscriptions)
-        end
+          reply_markup: subscriptions_keyboard(current_user.subscriptions.active.by_created_at)
       end
     end
 
@@ -130,9 +88,7 @@ module Telegram::SubscriptionCommands
 
       subscriptions.each do |subscription|
         channel = subscription.channel
-        text += I18n.t('telegram_bot.channels.list.channel_info',
-          channel: channel.title.present? ? channel.title : "@#{channel.username}",
-          priority: subscription.priority)
+        text += "• #{channel.title.present? ? channel.title : "@#{channel.username}"}"
         text += "\n"
       end
 
@@ -145,14 +101,6 @@ module Telegram::SubscriptionCommands
 
       keyboard = subscriptions.map do |subscription|
         keyboard_row(
-          callback_button(
-            I18n.t('telegram_bot.channels.list.buttons.priority_up'),
-            "priority_up:#{subscription.channel_id}"
-          ),
-          callback_button(
-            I18n.t('telegram_bot.channels.list.buttons.priority_down'),
-            "priority_down:#{subscription.channel_id}"
-          ),
           callback_button(
             I18n.t('telegram_bot.channels.list.buttons.remove'),
             "remove_channel:#{subscription.channel_id}"

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,12 +5,11 @@ class Subscription < ApplicationRecord
 
   # Validations
   validates :telegram_user_id, uniqueness: { scope: :channel_id }
-  validates :priority, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
 
   # Scopes
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
-  scope :by_priority, -> { order(priority: :desc) }
+  scope :by_created_at, -> { order(created_at: :desc) }
   scope :for_user, ->(user) { where(telegram_user: user) }
   scope :for_channel, ->(channel) { where(channel: channel) }
 

--- a/app/services/telegram/channel_service.rb
+++ b/app/services/telegram/channel_service.rb
@@ -170,7 +170,6 @@ module Telegram
       # Создаем подписку
       subscription = user.subscriptions.build(
         channel: channel,
-        priority: 5, # средний приоритет по умолчанию
         active: true
       )
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -130,14 +130,10 @@ ru:
         title: "📋 Мои подписки"
         empty: "У тебя пока нет подписок. Просто накидай каналы в чат списком, и я их добавлю."
         total: "Всего каналов: %{count}"
-        channel_info: "• %{channel} (приоритет: %{priority})"
         buttons:
           remove: "🗑️"
-          priority_up: "⬆️"
-          priority_down: "⬇️"
           settings: "⚙️"
         confirm_remove: "Удалить %{channel} из подписок?"
-        priority_updated: "Приоритет %{channel} изменён на %{priority}"
         remove_success: "Канал %{channel} удалён из подписок"
 
     settings:

--- a/db/migrate/20251006_remove_priority_from_subscriptions.rb
+++ b/db/migrate/20251006_remove_priority_from_subscriptions.rb
@@ -1,0 +1,15 @@
+class RemovePriorityFromSubscriptions < ActiveRecord::Migration[8.0]
+  def up
+    # Удаляем колонку priority
+    remove_column :subscriptions, :priority
+
+    # Удаляем индекс по полю priority если он существует
+    remove_index :subscriptions, :priority if index_exists?(:subscriptions, :priority)
+  end
+
+  def down
+    # Восстанавливаем колонку priority для возможности отката миграции
+    add_column :subscriptions, :priority, :integer, default: 5, null: false
+    add_index :subscriptions, :priority
+  end
+end

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -3,15 +3,13 @@
 one:
   telegram_user: one
   channel: one
-  priority: 1
   active: false
   last_digest_sent_at: 2025-10-01 14:37:48
-  settings: 
+  settings:
 
 two:
   telegram_user: two
   channel: two
-  priority: 1
   active: false
   last_digest_sent_at: 2025-10-01 14:37:48
   settings: 

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -39,8 +39,7 @@ class SubscriptionTest < ActiveSupport::TestCase
   test 'should be valid with valid attributes' do
     subscription = Subscription.new(
       telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: 5
+      channel: channels(:two)
     )
     assert subscription.valid?
   end
@@ -49,8 +48,7 @@ class SubscriptionTest < ActiveSupport::TestCase
     existing_subscription = subscriptions(:one)
     subscription = Subscription.new(
       telegram_user: existing_subscription.telegram_user,
-      channel: existing_subscription.channel,
-      priority: 5
+      channel: existing_subscription.channel
     )
     assert_not subscription.valid?
     assert subscription.errors[:telegram_user_id].present?
@@ -64,8 +62,7 @@ class SubscriptionTest < ActiveSupport::TestCase
 
     subscription2 = Subscription.new(
       telegram_user: user,
-      channel: channel2,
-      priority: 5
+      channel: channel2
     )
     assert subscription2.valid?
   end
@@ -79,68 +76,9 @@ class SubscriptionTest < ActiveSupport::TestCase
 
     subscription2 = Subscription.new(
       telegram_user: user2,
-      channel: channel,
-      priority: 5
+      channel: channel
     )
     assert subscription2.valid?
-  end
-
-  test 'should require priority' do
-    subscription = Subscription.new(
-      telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: nil
-    )
-    assert_not subscription.valid?
-    assert subscription.errors[:priority].present?
-  end
-
-  test 'should require priority to be an integer' do
-    subscription = Subscription.new(
-      telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: 5.5
-    )
-    assert_not subscription.valid?
-    assert subscription.errors[:priority].present?
-  end
-
-  test 'should require priority to be greater than or equal to 1' do
-    subscription = Subscription.new(
-      telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: 0
-    )
-    assert_not subscription.valid?
-    assert subscription.errors[:priority].present?
-  end
-
-  test 'should require priority to be less than or equal to 10' do
-    subscription = Subscription.new(
-      telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: 11
-    )
-    assert_not subscription.valid?
-    assert subscription.errors[:priority].present?
-  end
-
-  test 'should accept priority of 1' do
-    subscription = Subscription.new(
-      telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: 1
-    )
-    assert subscription.valid?
-  end
-
-  test 'should accept priority of 10' do
-    subscription = Subscription.new(
-      telegram_user: telegram_users(:one),
-      channel: channels(:two),
-      priority: 10
-    )
-    assert subscription.valid?
   end
 
   # Scope tests
@@ -176,14 +114,15 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_not_includes inactive_subscriptions, subscription
   end
 
-  test 'by_priority scope should order subscriptions by priority descending' do
+  test 'by_created_at scope should order subscriptions by created_at descending' do
     subscription1 = subscriptions(:one)
-    subscription1.update(priority: 3)
-
     subscription2 = subscriptions(:two)
-    subscription2.update(priority: 8)
 
-    ordered_subscriptions = Subscription.by_priority
+    # Ensure they have different created_at timestamps
+    subscription1.update!(created_at: 2.hours.ago)
+    subscription2.update!(created_at: 1.hour.ago)
+
+    ordered_subscriptions = Subscription.by_created_at
     assert_equal subscription2, ordered_subscriptions.first
     assert_equal subscription1, ordered_subscriptions.second
   end
@@ -269,7 +208,6 @@ class SubscriptionTest < ActiveSupport::TestCase
     subscription = Subscription.new(
       telegram_user: telegram_users(:one),
       channel: channels(:two),
-      priority: 5,
       active: nil,
       last_digest_sent_at: nil,
       settings: nil
@@ -290,7 +228,6 @@ class SubscriptionTest < ActiveSupport::TestCase
     subscription = Subscription.new(
       telegram_user: telegram_users(:one),
       channel: channels(:two),
-      priority: 5,
       settings: nil
     )
     assert subscription.valid?

--- a/test/services/telegram/channel_service_test.rb
+++ b/test/services/telegram/channel_service_test.rb
@@ -165,7 +165,6 @@ class Telegram::ChannelServiceTest < ActiveSupport::TestCase
     subscription = Subscription.create!(
       telegram_user: @user,
       channel: channel,
-      priority: 5,
       active: true
     )
 
@@ -197,7 +196,6 @@ class Telegram::ChannelServiceTest < ActiveSupport::TestCase
       subscription = Subscription.create!(
         telegram_user: @user,
         channel: channel,
-        priority: 5,
         active: true
       )
 


### PR DESCRIPTION
Убери приоритет из списка каналов по /list. Если в базе есть приоритет то объясни для чего он. Если для сортировки то используй created_at и удали это поле. Предложи план реализации.