### PR TITLE
Когда смотрю список каналов вижу 📊 Список каналов в системе (всего: %{count}) (vibe-kanban)

### DIFF
--- a/app/controllers/concerns/telegram/subscription_commands.rb
+++ b/app/controllers/concerns/telegram/subscription_commands.rb
@@ -76,7 +76,7 @@ module Telegram::SubscriptionCommands
 
     # Построить текст списка подписок
     def build_subscriptions_list(subscriptions)
-      text = "#{I18n.t('telegram_bot.channels.list.title')}\n\n"
+      text = "#{I18n.t('telegram_bot.channels.list.title', count: subscriptions.count)}\n\n"
       text += "#{I18n.t('telegram_bot.channels.list.total', count: subscriptions.count)}\n\n"
 
       subscriptions.each do |subscription|


### PR DESCRIPTION
похоже что количество каналов не попадает в сообщение